### PR TITLE
Feature / auth / password reset

### DIFF
--- a/src/main/java/redot/redot_server/domain/auth/controller/EmailVerificationController.java
+++ b/src/main/java/redot/redot_server/domain/auth/controller/EmailVerificationController.java
@@ -12,14 +12,7 @@ import redot.redot_server.domain.auth.dto.request.EmailVerificationSendRequest;
 import redot.redot_server.domain.auth.dto.request.EmailVerificationVerifyRequest;
 import redot.redot_server.domain.auth.dto.response.EmailVerificationSendResponse;
 import redot.redot_server.domain.auth.dto.response.EmailVerificationVerifyResponse;
-import redot.redot_server.domain.auth.exception.AuthErrorCode;
-import redot.redot_server.domain.auth.exception.AuthException;
-import redot.redot_server.domain.auth.model.EmailVerificationPurpose;
 import redot.redot_server.domain.auth.service.EmailVerificationService;
-import redot.redot_server.domain.cms.member.repository.CMSMemberRepository;
-import redot.redot_server.domain.admin.repository.AdminRepository;
-import redot.redot_server.domain.redot.member.repository.RedotMemberRepository;
-import redot.redot_server.global.util.EmailUtils;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,14 +20,10 @@ import redot.redot_server.global.util.EmailUtils;
 public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
-    private final RedotMemberRepository redotMemberRepository;
-    private final AdminRepository adminRepository;
-    private final CMSMemberRepository cmsMemberRepository;
 
     @PostMapping("/send")
     @Operation(summary = "이메일 인증 코드 발송")
     public ResponseEntity<EmailVerificationSendResponse> send(@RequestBody @Valid EmailVerificationSendRequest request) {
-        validatePurposeTarget(request);
         EmailVerificationSendResponse response = emailVerificationService.sendCode(request);
         return ResponseEntity.ok(response);
     }
@@ -46,27 +35,4 @@ public class EmailVerificationController {
         return ResponseEntity.ok(response);
     }
 
-    private void validatePurposeTarget(EmailVerificationSendRequest request) {
-        EmailVerificationPurpose purpose = request.purpose();
-        if (purpose == null) {
-            throw new AuthException(AuthErrorCode.UNSUPPORTED_EMAIL_VERIFICATION_PURPOSE);
-        }
-        String normalizedEmail = EmailUtils.normalize(request.email());
-        switch (purpose) {
-            case REDOT_MEMBER_PASSWORD_RESET -> redotMemberRepository.findByEmail(normalizedEmail)
-                    .orElseThrow(() -> new AuthException(AuthErrorCode.REDOT_MEMBER_NOT_FOUND));
-            case REDOT_ADMIN_PASSWORD_RESET -> adminRepository.findByEmailIgnoreCase(normalizedEmail)
-                    .orElseThrow(() -> new AuthException(AuthErrorCode.ADMIN_NOT_FOUND));
-            case CMS_MEMBER_PASSWORD_RESET -> {
-                Long redotAppId = request.redotAppId();
-                if (redotAppId == null) {
-                    throw new AuthException(AuthErrorCode.REDOT_APP_CONTEXT_REQUIRED);
-                }
-                cmsMemberRepository.findByEmailIgnoreCaseAndRedotApp_Id(normalizedEmail, redotAppId)
-                        .orElseThrow(() -> new AuthException(AuthErrorCode.CMS_MEMBER_NOT_FOUND));
-            }
-            default -> {
-            }
-        }
-    }
 }

--- a/src/main/java/redot/redot_server/domain/auth/dto/request/EmailVerificationSendRequest.java
+++ b/src/main/java/redot/redot_server/domain/auth/dto/request/EmailVerificationSendRequest.java
@@ -14,7 +14,7 @@ public record EmailVerificationSendRequest(
         @Schema(description = "인증 용도")
         @NotNull
         EmailVerificationPurpose purpose,
-        @Schema(description = "CMS 멤버 비밀번호 초기화 시 사용할 RedotApp ID", nullable = true)
-        Long redotAppId
+        @Schema(description = "CMS 멤버 비밀번호 초기화 시 사용할 RedotApp의 Subdomain", nullable = true)
+        String redotAppSubdomain
 ) {
 }


### PR DESCRIPTION


## Overview
<!-- PR을 설명해주세요. -->
- 프론트엔드의 요청으로 기존 CMS 맴버의 비밀번호 초기화시 redotAppId를 받아서 검증하던 부분을 subdomain을 받아 redotAppId를 찾고 CMS 맴버가 존재하는지 검증하는 로직으로 수정 구현하였어요.
---

## Related Issue
<!-- 관련 이슈를 명시해주세요. -->

- Closes #92 

---

## PR Checklist
<!-- PR 체크리스트를 적어주세요 -->

- [ ]

---

## Additional Information
<!-- 이슈 사항, 리뷰어가 참고하면 좋을 만한 사항 등 -->
